### PR TITLE
feat: Member Engagement Score Display

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -12,8 +12,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">
-    <script type="module" crossorigin src="/assets/index-CW0I0wKp.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-_93_7i54.css">
+    <script type="module" crossorigin src="/assets/index-Did5PH91.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BqLLnFNX.css">
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/MemberEngagementScore.tsx
+++ b/client/src/components/MemberEngagementScore.tsx
@@ -1,0 +1,135 @@
+import { useEngagementMetrics } from "@/hooks/use-member-activity";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Loader2, Tv, Heart, Calendar, BookOpen, MessageSquare, Clock } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
+
+export function MemberEngagementScore() {
+  const { data: metrics, isLoading } = useEngagementMetrics();
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex justify-center py-6">
+          <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!metrics) {
+    return null;
+  }
+
+  const calculateScore = () => {
+    const weights = {
+      sermonsWatched: 20,
+      prayersSubmitted: 15,
+      eventsAttended: 25,
+      devotionalsRead: 20,
+      groupMessages: 10,
+      loginCount: 10,
+    };
+
+    const maxValues = {
+      sermonsWatched: 50,
+      prayersSubmitted: 30,
+      eventsAttended: 20,
+      devotionalsRead: 50,
+      groupMessages: 100,
+      loginCount: 30,
+    };
+
+    let totalScore = 0;
+    let totalWeight = 0;
+
+    Object.keys(weights).forEach((key) => {
+      const weight = weights[key as keyof typeof weights];
+      const value = metrics[key as keyof typeof metrics] as number || 0;
+      const max = maxValues[key as keyof typeof maxValues];
+      const normalized = Math.min(value / max, 1);
+      totalScore += normalized * weight;
+      totalWeight += weight;
+    });
+
+    return Math.round((totalScore / totalWeight) * 100);
+  };
+
+  const score = calculateScore();
+
+  const getScoreColor = (s: number) => {
+    if (s >= 80) return "text-green-600";
+    if (s >= 60) return "text-blue-600";
+    if (s >= 40) return "text-yellow-600";
+    return "text-red-600";
+  };
+
+  const getScoreLabel = (s: number) => {
+    if (s >= 80) return "Highly Engaged";
+    if (s >= 60) return "Active";
+    if (s >= 40) return "Moderately Active";
+    return "Getting Started";
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Heart className="h-5 w-5 text-primary" />
+          Spiritual Engagement Score
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="mb-6 text-center">
+          <div className={`text-5xl font-bold ${getScoreColor(score)}`}>{score}</div>
+          <p className="text-sm text-muted-foreground mt-1">{getScoreLabel(score)}</p>
+          <Progress value={score} className="mt-3" />
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <div className="flex items-center gap-2">
+            <Tv className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">{metrics.sermonsWatched || 0}</p>
+              <p className="text-xs text-muted-foreground">Sermons</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Heart className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">{metrics.prayersSubmitted || 0}</p>
+              <p className="text-xs text-muted-foreground">Prayers</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">{metrics.eventsAttended || 0}</p>
+              <p className="text-xs text-muted-foreground">Events</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">{metrics.devotionalsRead || 0}</p>
+              <p className="text-xs text-muted-foreground">Devotionals</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">{metrics.groupMessages || 0}</p>
+              <p className="text-xs text-muted-foreground">Messages</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">{Math.round((metrics.totalSessionTime || 0) / 60)}m</p>
+              <p className="text-xs text-muted-foreground">Session</p>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ import { buildApiUrl } from "@/lib/api-config";
 import { User, Mail, Calendar, Shield, Heart, Loader2, Phone, MapPin, Home, Building, Edit, MessageSquare, Bell, Check, Users, UserX, Send, Reply, Briefcase, Cake, AlertCircle, Play, Trash2, QrCode, Download } from "lucide-react";
 import { Link } from "wouter";
 import { DashboardWidgets } from "@/components/DashboardWidgets";
+import { MemberEngagementScore } from "@/components/MemberEngagementScore";
 import { formatDistanceToNow, format } from "date-fns";
 import { QRCodeSVG } from "qrcode.react";
 
@@ -235,6 +236,8 @@ export default function DashboardPage() {
         </div>
 
         <DashboardWidgets />
+
+        <MemberEngagementScore />
 
         <div className="grid gap-4 sm:gap-6 md:grid-cols-2">
           {/* Profile Completeness */}


### PR DESCRIPTION
## Summary
- Implements Member Engagement Score Display feature (closes #1071)
- Creates MemberEngagementScore component with weighted scoring algorithm
- Displays individual metrics: sermons, prayers, events, devotionals, messages
- Shows overall engagement score with progress bar and level label
- Integrates into DashboardPage below DashboardWidgets

## Changes
- `client/src/components/MemberEngagementScore.tsx`: New component displaying engagement metrics and calculated score
- `client/src/pages/DashboardPage.tsx`: Added MemberEngagementScore component to dashboard layout

## Scoring Algorithm
- Sermons Watched: 20% weight (max 50)
- Events Attended: 25% weight (max 20)
- Prayers Submitted: 15% weight (max 30)
- Devotionals Read: 20% weight (max 50)
- Group Messages: 10% weight (max 100)
- Login Count: 10% weight (max 30)

Closes #1071