### PR TITLE
feat: Quick Donate PWA Widget

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#4f46e5" />
     <title>CHub - Church Community Platform</title>
     <meta name="description" content="CHub - Your Church Community Management Platform" />
     <meta property="og:title" content="CHub - Church Community Platform" />

--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#4f46e5" />
     <title>CHub - Church Community Platform</title>
     <meta name="description" content="CHub - Your Church Community Management Platform" />
     <meta property="og:title" content="CHub - Church Community Platform" />

--- a/client/src/components/QuickDonate.tsx
+++ b/client/src/components/QuickDonate.tsx
@@ -3,16 +3,24 @@
 import { Heart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link } from "wouter";
+import { useEffect, useState } from "react";
 
 export function QuickDonate() {
+  const [isPWA, setIsPWA] = useState(false);
+
+  useEffect(() => {
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+    setIsPWA(isStandalone);
+  }, []);
+
   return (
     <Link href="/give">
       <Button
-        className="fixed bottom-6 left-6 z-40 rounded-full h-14 px-6 shadow-lg gradient-accent text-primary-foreground font-bold"
+        className={`${isPWA ? 'fixed top-4 left-4' : 'fixed bottom-6 left-6'} z-40 rounded-full h-14 px-6 shadow-lg gradient-accent text-primary-foreground font-bold transition-all`}
         title="Quick Donate"
       >
         <Heart className="w-5 h-5 mr-2 fill-current" />
-        <span className="hidden sm:inline">Give</span>
+        <span>Give</span>
       </Button>
     </Link>
   );


### PR DESCRIPTION
## Summary
- Implements Quick Donate PWA Widget feature (closes #1072)
- Creates manifest.json with PWA shortcuts including Quick Donate
- Adds manifest link and theme-color meta to index.html
- Updates QuickDonate component to detect PWA standalone mode
- Enables add-to-home-screen with quick donate shortcut

## Changes
- `client/public/manifest.json`: New PWA manifest with shortcuts
- `client/index.html`: Added manifest link and theme-color meta
- `client/src/components/QuickDonate.tsx`: Updated to detect PWA mode

## PWA Features
- Users can now "Add to Home Screen" 
- Quick Donate shortcut appears in PWA app list
- Button position adapts for PWA standalone vs browser mode

Closes #1072