### PR TITLE
Add Caching for Frequently Accessed Data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "multiparty": "^4.2.3",
         "nanoid": "^5.1.6",
         "next-themes": "^0.4.6",
+        "node-cache": "^5.1.2",
         "node-rdkafka": "^3.6.1",
         "nodemailer": "^8.0.0",
         "openid-client": "^6.8.1",
@@ -7655,6 +7656,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cloudflare-video-element": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/cloudflare-video-element/-/cloudflare-video-element-1.3.5.tgz",
@@ -12823,6 +12833,18 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "multiparty": "^4.2.3",
     "nanoid": "^5.1.6",
     "next-themes": "^0.4.6",
+    "node-cache": "^5.1.2",
     "node-rdkafka": "^3.6.1",
     "nodemailer": "^8.0.0",
     "openid-client": "^6.8.1",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,6 +6,10 @@ import { supportedLanguages, groupJoinRequests, groupActivityLogs, volunteerSkil
 import { eq, desc } from "drizzle-orm";
 import { api } from "@shared/routes";
 import rateLimit from 'express-rate-limit';
+import NodeCache from 'node-cache';
+
+// Cache instance (TTL: 5 minutes)
+const cache = new NodeCache({ stdTTL: 300, checkperiod: 320 });
 
 // Rate limiters for auth endpoints
 const loginLimiter = rateLimit({
@@ -1811,20 +1815,34 @@ app.post("/api/auth/login", loginLimiter, async (req, res) => {
     }
   });
 
-  // Sermons
+  // Sermons (with caching)
   app.get(api.sermons.list.path, async (req: AuthenticatedRequest, res) => {
     const { speaker, series, status, search } = req.query;
     const orgId = getOrganizationId(req);
+
+    // Create cache key from query params
+    const cacheKey = `sermons:${orgId}:${speaker || ''}:${series || ''}:${status || ''}:${search || ''}`;
+
+    // Check cache
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      return res.json(cached);
+    }
+
     const filter: ISermonFilter = {};
-    
+
     if (speaker) filter.speaker = speaker as string;
     if (series) filter.series = series as string;
     if (search) filter.search = search as string;
     if (status === 'upcoming') filter.isUpcoming = true;
     if (status === 'past') filter.isUpcoming = false;
     if (orgId) filter.organizationId = orgId;
-    
+
     const sermons = await storage.getSermons(filter);
+
+    // Cache the result
+    cache.set(cacheKey, sermons);
+
     res.json(sermons);
   });
 


### PR DESCRIPTION
## Description
Partial implementation for #1137

Adds caching for frequently accessed data.

## Changes
- Install `node-cache` package
- Add cache instance with 5min TTL
- Cache sermons list endpoint with query-based keys

## TODO
- [ ] Add cache invalidation on create/update/delete
- [ ] Add caching to other endpoints (events, resources)
- [ ] Consider Redis for distributed caching