### PR TITLE
feat: add environment-specific configuration setup

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,6 +7,18 @@ DATABASE_URL=postgres://chubuser:chubpass123@localhost:5432/community_hub
 
 # Session
 SESSION_SECRET=dev-secret-key-change-in-production-min-32-chars
+JWT_SECRET=dev-jwt-secret-change-in-production-min-32-chars
+
+# Public app URL
+APP_URL=http://localhost:5000
+
+# Client/API
+CLIENT_API_URL=http://localhost:5000/api
+
+# Feature flags
+ENABLE_NOTIFICATIONS=true
+ENABLE_WEBSOCKETS=true
+ENABLE_ANALYTICS=false
 
 # Kafka (Optional)
 # KAFKA_BROKERS=localhost:9092

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,18 @@ DATABASE_URL=postgres://user:password@localhost:5432/database
 
 # Session
 SESSION_SECRET=your-super-secret-session-key-min-32-chars
+JWT_SECRET=your-jwt-secret-min-32-chars
+
+# Public app URL
+APP_URL=http://localhost:5000
+
+# Client/API
+CLIENT_API_URL=http://localhost:5000/api
+
+# Feature flags
+ENABLE_NOTIFICATIONS=true
+ENABLE_WEBSOCKETS=true
+ENABLE_ANALYTICS=false
 
 # Kafka (Optional)
 KAFKA_BROKERS=localhost:9092

--- a/.env.production
+++ b/.env.production
@@ -7,6 +7,18 @@ DATABASE_URL=postgres://user:password@host:5432/database
 
 # Session (MUST be changed to a secure random string)
 SESSION_SECRET=your-production-session-secret-here-min-32-chars
+JWT_SECRET=your-production-jwt-secret-here-min-32-chars
+
+# Public app URL
+APP_URL=https://community-hub.app
+
+# Client/API
+CLIENT_API_URL=https://community-hub.app/api
+
+# Feature flags
+ENABLE_NOTIFICATIONS=true
+ENABLE_WEBSOCKETS=true
+ENABLE_ANALYTICS=true
 
 # Kafka (Optional)
 # KAFKA_BROKERS=your-kafka-broker:9092

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,24 @@
+# Staging environment
+NODE_ENV=staging
+PORT=5000
+
+# Database
+DATABASE_URL=postgres://user:password@staging-host:5432/community_hub_staging
+
+# Session and auth
+SESSION_SECRET=replace-with-staging-session-secret-min-32-chars
+JWT_SECRET=replace-with-staging-jwt-secret-min-32-chars
+
+# Public app URL
+APP_URL=https://staging.community-hub.app
+
+# Client/API
+CLIENT_API_URL=https://staging.community-hub.app/api
+
+# Feature flags
+ENABLE_NOTIFICATIONS=true
+ENABLE_WEBSOCKETS=true
+ENABLE_ANALYTICS=true
+
+# Optional services
+# KAFKA_BROKERS=staging-kafka:9092

--- a/README.md
+++ b/README.md
@@ -97,7 +97,21 @@ npm install
 ```
 
 ### 3. Environment Configuration
-Create a `.env` file in the root directory:
+Use environment-specific files in the project root. The server automatically loads the file matching `NODE_ENV`:
+
+- Development: `.env.development`
+- Staging: `.env.staging`
+- Production: `.env.production`
+
+You can copy from `.env.example` and update values per environment.
+
+```bash
+cp .env.example .env.development
+cp .env.example .env.staging
+cp .env.example .env.production
+```
+
+Root environment template:
 
 ```bash
 # Database Configuration
@@ -105,11 +119,25 @@ DATABASE_URL=postgresql://username:password@host:port/database?sslmode=require
 
 # Authentication
 SESSION_SECRET=your_secure_session_secret
+JWT_SECRET=your_jwt_secret
+APP_URL=http://localhost:5000
+CLIENT_API_URL=http://localhost:5000/api
+
+# Feature Flags
+ENABLE_NOTIFICATIONS=true
+ENABLE_WEBSOCKETS=true
+ENABLE_ANALYTICS=false
 
 # Optional: Object Storage
 PUBLIC_OBJECT_SEARCH_PATHS=path1,path2
 PRIVATE_OBJECT_DIR=your_private_directory
 ```
+
+Client environment files live in `client/.env.development`, `client/.env.staging`, and `client/.env.production` and define:
+
+- `VITE_API_URL` / `VITE_API_BASE_URL` for environment-specific API URLs
+- `VITE_WS_URL` for realtime socket URL
+- `VITE_FEATURE_NOTIFICATIONS`, `VITE_FEATURE_WEBSOCKETS`, `VITE_FEATURE_ANALYTICS` for frontend feature flags
 
 ### 4. Database Setup
 ```bash

--- a/api/config.ts
+++ b/api/config.ts
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+import { loadEnv } from "../shared/load-env";
 
-dotenv.config();
+loadEnv();
 
 // Validate required environment variables
 const requiredEnvVars = ['JWT_SECRET', 'DATABASE_URL'];

--- a/client/.env.development
+++ b/client/.env.development
@@ -1,0 +1,9 @@
+VITE_API_BASE_URL=/api
+VITE_API_URL=http://localhost:5000/api
+VITE_WS_URL=ws://localhost:5000
+VITE_DEV_MODE=true
+
+# Feature flags
+VITE_FEATURE_NOTIFICATIONS=true
+VITE_FEATURE_WEBSOCKETS=true
+VITE_FEATURE_ANALYTICS=false

--- a/client/.env.example
+++ b/client/.env.example
@@ -15,6 +15,11 @@ VITE_API_URL=https://your-domain.com/api
 # Example: wss://community-hub.onrender.com
 VITE_WS_URL=wss://your-domain.com
 
+# Feature flags
+VITE_FEATURE_NOTIFICATIONS=true
+VITE_FEATURE_WEBSOCKETS=true
+VITE_FEATURE_ANALYTICS=true
+
 # =============================================================================
 # AFTER DEPLOYMENT - UPDATE THESE
 # =============================================================================

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,0 +1,9 @@
+VITE_API_BASE_URL=/api
+VITE_API_URL=https://community-hub.app/api
+VITE_WS_URL=wss://community-hub.app
+VITE_DEV_MODE=false
+
+# Feature flags
+VITE_FEATURE_NOTIFICATIONS=true
+VITE_FEATURE_WEBSOCKETS=true
+VITE_FEATURE_ANALYTICS=true

--- a/client/.env.staging
+++ b/client/.env.staging
@@ -1,0 +1,9 @@
+VITE_API_BASE_URL=/api
+VITE_API_URL=https://staging.community-hub.app/api
+VITE_WS_URL=wss://staging.community-hub.app
+VITE_DEV_MODE=false
+
+# Feature flags
+VITE_FEATURE_NOTIFICATIONS=true
+VITE_FEATURE_WEBSOCKETS=true
+VITE_FEATURE_ANALYTICS=true

--- a/client/src/lib/api-config.ts
+++ b/client/src/lib/api-config.ts
@@ -2,18 +2,31 @@
 
 // Get environment variables
 const env = (import.meta as any).env || {};
+const mode = env.MODE || "development";
 
 // Use VITE_API_URL if set (full URL), otherwise fall back to relative path
 const API_URL = env.VITE_API_URL || env.VITE_API_BASE_URL || '';
 
 // Determine if we're in development mode
-const isDev = env.DEV || env.VITE_DEV_MODE === 'true' || window.location.hostname === 'localhost' || window.location.hostname.endsWith('.local');
+const isDev =
+  env.DEV ||
+  mode === "development" ||
+  env.VITE_DEV_MODE === 'true' ||
+  window.location.hostname === 'localhost' ||
+  window.location.hostname.endsWith('.local');
 
 // For development, use relative paths so that it targets the same origin
 const DEV_API_URL = '';
 
 // Base domain for multi-tenant subdomains
 const BASE_DOMAIN = isDev ? 'chub.local' : 'chub.app';
+
+// Environment-specific feature flags (defaults allow current behavior)
+export const featureFlags = {
+  notifications: env.VITE_FEATURE_NOTIFICATIONS !== "false",
+  websockets: env.VITE_FEATURE_WEBSOCKETS !== "false",
+  analytics: env.VITE_FEATURE_ANALYTICS !== "false",
+} as const;
 
 // Store current organization info
 const ORG_INFO_KEY = 'chub_org_info';

--- a/server/add-indexes.ts
+++ b/server/add-indexes.ts
@@ -1,8 +1,8 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
-import dotenv from 'dotenv';
+import { loadEnv } from "../shared/load-env";
 
-dotenv.config();
+loadEnv();
 
 const runIndexes = async () => {
   if (!process.env.DATABASE_URL) {

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+import { loadEnv } from "../shared/load-env";
 
-dotenv.config();
+loadEnv();
 
 // Validate required environment variables
 const requiredEnvVars = ['JWT_SECRET', 'DATABASE_URL'];

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config';
+import { loadEnv } from "../shared/load-env";
 import express, { type Request, Response, NextFunction } from "express";
 import cookieParser from "cookie-parser";
 import helmet from "helmet";
@@ -11,6 +11,8 @@ import { swaggerSpec } from "./swagger";
 import validateEnv from "./validateEnv";
 import logger from "./logger";
 import { errorHandler } from "./errorHandler";
+
+loadEnv();
 
 // Initialize Sentry (if DSN provided)
 if (process.env.SENTRY_DSN) {

--- a/server/migrate.ts
+++ b/server/migrate.ts
@@ -1,9 +1,9 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import postgres from 'postgres';
-import dotenv from 'dotenv';
+import { loadEnv } from "../shared/load-env";
 
-dotenv.config();
+loadEnv();
 
 const runMigrations = async () => {
   if (!process.env.DATABASE_URL) {

--- a/server/validateEnv.ts
+++ b/server/validateEnv.ts
@@ -1,14 +1,24 @@
 interface EnvConfig {
   DATABASE_URL: string;
   SESSION_SECRET: string;
+  JWT_SECRET?: string;
   NODE_ENV?: string;
+  APP_URL?: string;
   KAFKA_BROKERS?: string;
   SUPER_ADMIN_EMAIL?: string;
   SUPER_ADMIN_PASSWORD?: string;
+  CLIENT_API_URL?: string;
+  ENABLE_NOTIFICATIONS?: string;
+  ENABLE_WEBSOCKETS?: string;
+  ENABLE_ANALYTICS?: string;
 }
 
 function validateEnv(): EnvConfig {
+  const nodeEnv = process.env.NODE_ENV || "development";
   const requiredVars = ['DATABASE_URL', 'SESSION_SECRET'];
+  if (nodeEnv === "production" || nodeEnv === "staging") {
+    requiredVars.push("JWT_SECRET", "APP_URL");
+  }
   const missingVars = requiredVars.filter(varName => !process.env[varName]);
 
   if (missingVars.length > 0) {
@@ -27,13 +37,28 @@ function validateEnv(): EnvConfig {
     console.warn('WARNING: SESSION_SECRET should be at least 32 characters long');
   }
 
+  const appUrl = process.env.APP_URL;
+  if (appUrl) {
+    try {
+      new URL(appUrl);
+    } catch {
+      throw new Error("APP_URL must be a valid URL");
+    }
+  }
+
   return {
     DATABASE_URL: process.env.DATABASE_URL!,
     SESSION_SECRET: process.env.SESSION_SECRET!,
-    NODE_ENV: process.env.NODE_ENV,
+    JWT_SECRET: process.env.JWT_SECRET,
+    NODE_ENV: nodeEnv,
+    APP_URL: process.env.APP_URL,
     KAFKA_BROKERS: process.env.KAFKA_BROKERS,
     SUPER_ADMIN_EMAIL: process.env.SUPER_ADMIN_EMAIL,
     SUPER_ADMIN_PASSWORD: process.env.SUPER_ADMIN_PASSWORD,
+    CLIENT_API_URL: process.env.CLIENT_API_URL,
+    ENABLE_NOTIFICATIONS: process.env.ENABLE_NOTIFICATIONS,
+    ENABLE_WEBSOCKETS: process.env.ENABLE_WEBSOCKETS,
+    ENABLE_ANALYTICS: process.env.ENABLE_ANALYTICS,
   };
 }
 

--- a/shared/load-env.ts
+++ b/shared/load-env.ts
@@ -1,0 +1,29 @@
+import dotenv from "dotenv";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+let didLoad = false;
+
+export function loadEnv() {
+  if (didLoad) return;
+
+  const nodeEnv = process.env.NODE_ENV || "development";
+  const envFile = path.join(projectRoot, `.env.${nodeEnv}`);
+  const fallbackFile = path.join(projectRoot, ".env");
+
+  if (fs.existsSync(envFile)) {
+    dotenv.config({ path: envFile });
+  } else if (fs.existsSync(fallbackFile)) {
+    dotenv.config({ path: fallbackFile });
+  } else {
+    dotenv.config();
+  }
+
+  didLoad = true;
+}
+


### PR DESCRIPTION
## Summary
- load root env files based on `NODE_ENV` with support for `.env.development`, `.env.staging`, and `.env.production`
- add server/client environment templates for development, staging, and production including API URL and feature flag variables
- add per-environment validation and README documentation for environment setup

## Test plan
- [x] Run `npm run build` from repo root
- [x] Confirm client build succeeds with environment-aware API config
- [x] Verify no lint issues in changed files

Closes #1149

Made with [Cursor](https://cursor.com)