### PR TITLE
feat: Add Pagination to Tasks List Endpoint (P1 #1135)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5584,8 +5584,19 @@ Prayer: Thank You, Lord, for Your amazing grace and mercy. Help me to extend the
       if (req.query.projectId) filters.projectId = Number(req.query.projectId);
       if (req.query.assignedTo) filters.assignedTo = req.query.assignedTo as string;
       if (req.query.status) filters.status = req.query.status as string;
-      const tasks = await storage.getTasks(filters);
-      res.json(tasks);
+      
+      // Pagination parameters
+      const page = parseInt(req.query.page as string) || 1;
+      const limit = parseInt(req.query.limit as string) || 10;
+      const offset = (page - 1) * limit;
+      
+      const { tasks, total } = await storage.getTasks({ ...filters, limit, offset });
+      const totalPages = Math.ceil(total / limit);
+      
+      res.json({
+        tasks,
+        pagination: { page, limit, total, totalPages }
+      });
     } catch (err) {
       console.error("Error fetching tasks:", err);
       res.status(500).json({ message: "Internal server error" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5091,15 +5091,31 @@ export class DatabaseStorage implements IStorage {
     return db.select().from(tasks).where(eq(tasks.projectId, projectId)).orderBy(desc(tasks.createdAt));
   }
 
-  async getTasks(filters?: { projectId?: number; assignedTo?: string; status?: string }): Promise<Task[]> {
+  async getTasks(filters?: { projectId?: number; assignedTo?: string; status?: string; limit?: number; offset?: number }): Promise<{ tasks: Task[]; total: number }> {
     const conditions = [];
     if (filters?.projectId) conditions.push(eq(tasks.projectId, filters.projectId));
     if (filters?.assignedTo) conditions.push(eq(tasks.assignedTo, filters.assignedTo));
     if (filters?.status) conditions.push(eq(tasks.status, filters.status));
-    if (conditions.length > 0) {
-      return db.select().from(tasks).where(and(...conditions)).orderBy(desc(tasks.createdAt));
+    
+    // Build where condition
+    const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+    
+    // Get total count
+    const [{ count }] = await db.select({ count: sql<number>`count(*)` }).from(tasks).where(whereCondition);
+    const total = Number(count);
+    
+    // Get tasks with pagination
+    let query = db.select().from(tasks).where(whereCondition).orderBy(desc(tasks.createdAt));
+    
+    if (filters?.limit) {
+      query = query.limit(filters.limit);
     }
-    return db.select().from(tasks).orderBy(desc(tasks.createdAt));
+    if (filters?.offset) {
+      query = query.offset(filters.offset);
+    }
+    
+    const tasksList = await query;
+    return { tasks: tasksList, total };
   }
 
   async getTask(id: number): Promise<Task | undefined> {


### PR DESCRIPTION
## Summary\n- Add page and limit query parameters to /api/tasks\n- Return pagination metadata: { tasks, pagination: { page, limit, total, totalPages } }\n- Update storage.getTasks() to support limit and offset\n- Get total count for pagination metadata\n\nCloses #1135